### PR TITLE
doc: document release steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,14 @@
 
 This repository contains a set of tools to help with the integration of rattler-build into conda-forge.
 Mainly by providing an interface that is recognizable for uses used to `conda-build`
+
+## Releasing rattler-build-conda-compat
+
+1. update version in `pyproject.toml`
+2. run `pixi update rattler-build-conda-compat`
+3. open and merge PR with changes to pyproject.toml and pixi.lock
+4. Create a new release at https://github.com/conda-forge/rattler-build-conda-compat/releases/new with
+   - tag: vX.Y.Z
+   - title: vX.Y.Z
+   - Generate release notes
+   - click Publish Release

--- a/pixi.lock
+++ b/pixi.lock
@@ -11206,7 +11206,7 @@ packages:
 - pypi: ./
   name: rattler-build-conda-compat
   version: 1.4.9
-  sha256: ced92d0c9cb3d93a2c36f00adefccce20fd142f0285361cf992a9e296ee67dc2
+  sha256: a3fd54e09ee9b2db845f044d16e6b26132aa734afc19747771fd45e269bf9091
   requires_dist:
   - typing-extensions>=4.12,<5
   - jinja2>=3.0.2,<4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "rattler-build-conda-compat"
 description = "A package for exposing rattler-build API for conda-smithy"
-# run `pixi upgrade rattler-build-conda-compat` after changing
+# run `pixi update rattler-build-conda-compat` after changing
 version = "1.4.9"
 readme = "README.md"
 authors = [{ name = "Nichita Morcotilo", email = "nichita@prefix.dev" }]


### PR DESCRIPTION
fix upgrade/update in version comment

closes #33 since it doesn't describe how releases are currently published.